### PR TITLE
@JsonCreator대신 자동 constructor property 삽입 설정

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -24,8 +24,9 @@
  - **클래스 이름**: `[DomainName]``Dto`
  - 생성자와 `@Getter` 조합 사용
  - 인자가 너무 많으면(4개 이상) Builder로 전환
- - Response dto에서는 `@RequiredArgsConstructor`, `@AllArgsConstructor` 사용을 지양하자.
+ - Response dto에서는 `@AllArgsConstructor` 사용을 지양하자.
    - Field 순서가 뒤바뀌었을 때 dto가 가장 버그를 발견하기 어렵다.
+   - 가능한 불변성을 보장하는 `@RequiredArgsConstructor`를 사용.
    - Request Dto에서는 개발자가 아니라 spring이 만들어서 자동 주입해주므로 사용해도 문제없다.
 
 ## Test

--- a/lombok.config
+++ b/lombok.config
@@ -1,4 +1,5 @@
 lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value
 lombok.copyableannotations += com.dku.council.global.config.qualifier.ChromeAgentWebClient
+lombok.anyConstructor.addConstructorProperties = true
 lombok.Setter.flagUsage = error
 lombok.data.flagUsage = error

--- a/src/main/java/com/dku/council/domain/comment/model/dto/RequestCreateCommentDto.java
+++ b/src/main/java/com/dku/council/domain/comment/model/dto/RequestCreateCommentDto.java
@@ -1,13 +1,12 @@
 package com.dku.council.domain.comment.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@RequiredArgsConstructor(onConstructor_ = {@JsonCreator})
+@RequiredArgsConstructor
 public class RequestCreateCommentDto {
     @NotBlank
     private final String text;

--- a/src/main/java/com/dku/council/domain/post/model/dto/request/RequestCreateReplyDto.java
+++ b/src/main/java/com/dku/council/domain/post/model/dto/request/RequestCreateReplyDto.java
@@ -1,13 +1,12 @@
 package com.dku.council.domain.post.model.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@RequiredArgsConstructor(onConstructor_ = {@JsonCreator})
+@RequiredArgsConstructor
 public class RequestCreateReplyDto {
     @NotBlank
     private final String answer;

--- a/src/main/java/com/dku/council/domain/post/model/dto/response/ResponsePage.java
+++ b/src/main/java/com/dku/council/domain/post/model/dto/response/ResponsePage.java
@@ -1,9 +1,7 @@
 package com.dku.council.domain.post.model.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 
@@ -11,32 +9,31 @@ import java.io.Serializable;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResponsePage<T> implements Serializable {
 
     @Schema(description = "컨텐츠")
-    private List<T> content;
+    private final List<T> content;
 
     @Schema(description = "다음 페이지가 있는지?", example = "true")
-    private boolean hasNext;
+    private final boolean hasNext;
 
     @Schema(description = "총 페이지 수", example = "51")
-    private int totalPages;
+    private final int totalPages;
 
     @Schema(description = "총 요소 개수", example = "1021")
-    private long totalElements;
+    private final long totalElements;
 
     @Schema(description = "조회한 페이지", example = "3")
-    private int page;
+    private final int page;
 
     @Schema(description = "페이지 컨텐츠 개수", example = "20")
-    private int size;
+    private final int size;
 
     @Schema(description = "처음 페이지인지?", example = "false")
-    private boolean first;
+    private final boolean first;
 
     @Schema(description = "마지막 페이지인지?", example = "false")
-    private boolean last;
+    private final boolean last;
 
     public ResponsePage(Page<T> page) {
         final PageImpl<T> pageInfo = new PageImpl<>(page.getContent(), page.getPageable(), page.getTotalElements());

--- a/src/main/java/com/dku/council/domain/user/model/dto/request/RequestLoginDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/request/RequestLoginDto.java
@@ -1,12 +1,13 @@
 package com.dku.council.domain.user.model.dto.request;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestLoginDto {
 
     @NotBlank

--- a/src/main/java/com/dku/council/domain/user/model/dto/request/RequestRefreshTokenDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/request/RequestRefreshTokenDto.java
@@ -1,13 +1,13 @@
 package com.dku.council.domain.user.model.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@RequiredArgsConstructor(onConstructor_ = {@JsonCreator})
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestRefreshTokenDto {
 
     @NotBlank

--- a/src/main/java/com/dku/council/domain/user/model/dto/request/RequestSendSMSCodeDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/request/RequestSendSMSCodeDto.java
@@ -1,6 +1,6 @@
 package com.dku.council.domain.user.model.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,10 +9,11 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED, onConstructor_ = {@JsonCreator})
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestSendSMSCodeDto {
 
     @NotBlank
     @Pattern(regexp = "\\d{3}-*\\d{4}-*\\d{4}")
+    @Schema(description = "휴대폰 번호. 대시(-)는 있어도 되고 없어도 된다.", example = "010-1111-2222")
     private final String phoneNumber;
 }

--- a/src/main/java/com/dku/council/domain/user/model/dto/request/RequestSignupDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/request/RequestSignupDto.java
@@ -1,6 +1,5 @@
 package com.dku.council.domain.user.model.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED, onConstructor_ = {@JsonCreator})
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestSignupDto {
 
     @NotBlank

--- a/src/main/java/com/dku/council/domain/user/model/dto/request/RequestVerifySMSCodeDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/request/RequestVerifySMSCodeDto.java
@@ -1,6 +1,5 @@
 package com.dku.council.domain.user.model.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED, onConstructor_ = {@JsonCreator})
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestVerifySMSCodeDto {
 
     @NotBlank

--- a/src/main/java/com/dku/council/global/dto/ResponseIdDto.java
+++ b/src/main/java/com/dku/council/global/dto/ResponseIdDto.java
@@ -1,15 +1,10 @@
 package com.dku.council.global.dto;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
 public class ResponseIdDto {
-    private Long id;
-
-    public ResponseIdDto(Long id) {
-        this.id = id;
-    }
+    private final Long id;
 }

--- a/src/main/java/com/dku/council/infra/nhn/model/dto/response/ResponseNHNCloudSMS.java
+++ b/src/main/java/com/dku/council/infra/nhn/model/dto/response/ResponseNHNCloudSMS.java
@@ -1,24 +1,24 @@
 package com.dku.council.infra.nhn.model.dto.response;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@NoArgsConstructor(access = PROTECTED)
+@RequiredArgsConstructor(access = PROTECTED)
 public class ResponseNHNCloudSMS {
-    private Header header;
-    private Body body;
+    private final Header header;
+    private final Body body;
 
     @Getter
-    @NoArgsConstructor(access = PROTECTED)
+    @RequiredArgsConstructor(access = PROTECTED)
     public static class Header {
-        private boolean isSuccessful;
-        private int resultCode;
-        private String resultMessage;
+        private final boolean isSuccessful;
+        private final int resultCode;
+        private final String resultMessage;
 
         // isSuccessful은 @Getter tag로 인해 isSuccessful() getter가 만들어진다.
         // 그래서 파싱할 때 제대로 파싱이 안된다.
@@ -29,23 +29,23 @@ public class ResponseNHNCloudSMS {
     }
 
     @Getter
-    @NoArgsConstructor(access = PROTECTED)
+    @RequiredArgsConstructor(access = PROTECTED)
     public static class Body {
-        private Data data;
+        private final Data data;
 
         @Getter
-        @NoArgsConstructor(access = PROTECTED)
+        @RequiredArgsConstructor(access = PROTECTED)
         public static class Data {
-            private String requestId;
-            private String statusCode;
-            private List<SendResult> sendResultList;
+            private final String requestId;
+            private final String statusCode;
+            private final List<SendResult> sendResultList;
 
             @Getter
-            @NoArgsConstructor(access = PROTECTED)
+            @RequiredArgsConstructor(access = PROTECTED)
             public static class SendResult {
-                private String recipientNo;
-                private int resultCode;
-                private String resultMessage;
+                private final String recipientNo;
+                private final int resultCode;
+                private final String resultMessage;
             }
         }
     }

--- a/src/main/java/com/dku/council/infra/nhn/model/dto/response/ResponseToken.java
+++ b/src/main/java/com/dku/council/infra/nhn/model/dto/response/ResponseToken.java
@@ -1,28 +1,24 @@
 package com.dku.council.infra.nhn.model.dto.response;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@NoArgsConstructor(access = PROTECTED)
+@RequiredArgsConstructor(access = PROTECTED)
 public class ResponseToken {
-    private Access access;
-
-    public String getTokenId() {
-        return access.token.id;
-    }
+    private final Access access;
 
     @Getter
-    @NoArgsConstructor(access = PROTECTED)
+    @RequiredArgsConstructor(access = PROTECTED)
     public static class Access {
-        private Token token;
+        private final Token token;
     }
 
     @Getter
-    @NoArgsConstructor(access = PROTECTED)
+    @RequiredArgsConstructor(access = PROTECTED)
     public static class Token {
-        private String id;
+        private final String id;
     }
 }


### PR DESCRIPTION
기존에 DTO가 만들어지지 않는 문제를 해결하기위해 @JsonCreator를 생성자에 명시했었습니다.

이 방법보다 lombok.config에 한 줄만 추가하면 자동으로 생성자 설정을 추가해주는 옵션이 있어서 그렇게 수정했습니다.

이렇게 하면 `@NoArgsConstructor`없이 `@RequiredArgsConstructor`만으로도 jackson2jsonserializer가 dto를 생성할 수 있습니다.

주의할 점은 직접 만든 생성자가 여러 개 있는 경우에는 어쩔 수 없이 `@NoArgsConstructor`가 필요합니다.