### PR TITLE
좋아요 Redis cache clear안하는 버그

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ application.properties
 application.yml
 api.pdf
 
+/pinpoint-agent/

--- a/src/main/java/com/dku/council/domain/like/scheduler/PostLikeDumpScheduler.java
+++ b/src/main/java/com/dku/council/domain/like/scheduler/PostLikeDumpScheduler.java
@@ -1,6 +1,6 @@
 package com.dku.council.domain.like.scheduler;
 
-import com.dku.council.domain.like.service.PostLikeService;
+import com.dku.council.domain.like.service.impl.RedisPostLikeServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostLikeDumpScheduler {
 
-    private final PostLikeService service;
+    private final RedisPostLikeServiceImpl service;
 
     @Scheduled(fixedDelayString = "${app.post.like-dump-delay}")
     public void dumpToDB() {

--- a/src/main/java/com/dku/council/domain/like/service/PostLikeService.java
+++ b/src/main/java/com/dku/council/domain/like/service/PostLikeService.java
@@ -1,28 +1,6 @@
 package com.dku.council.domain.like.service;
 
-import com.dku.council.domain.like.model.LikeEntry;
-import com.dku.council.domain.like.model.LikeState;
-import com.dku.council.domain.like.model.entity.PostLike;
-import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
-import com.dku.council.domain.like.repository.PostLikePersistenceRepository;
-import com.dku.council.domain.post.model.entity.Post;
-import com.dku.council.domain.post.repository.PostRepository;
-import com.dku.council.domain.user.model.entity.User;
-import com.dku.council.domain.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-@Service
-@RequiredArgsConstructor
-public class PostLikeService {
-    private final PostLikeMemoryRepository memoryRepository;
-    private final PostLikePersistenceRepository persistenceRepository;
-    private final UserRepository userRepository;
-    private final PostRepository postRepository;
-
+public interface PostLikeService {
 
     /**
      * '좋아요' 처리
@@ -30,12 +8,7 @@ public class PostLikeService {
      * @param postId 게시글 ID
      * @param userId 사용자 ID
      */
-    public void like(Long postId, Long userId) {
-        if (!isPostLiked(postId, userId)) {
-            memoryRepository.addPostLike(postId, userId);
-            memoryRepository.setLikeCount(postId, getCountOfLikes(postId) + 1);
-        }
-    }
+    void like(Long postId, Long userId);
 
     /**
      * '좋아요' 취소 처리
@@ -43,12 +16,7 @@ public class PostLikeService {
      * @param postId 게시글 ID
      * @param userId 사용자 ID
      */
-    public void cancelLike(Long postId, Long userId) {
-        if (isPostLiked(postId, userId)) {
-            memoryRepository.removePostLike(postId, userId);
-            memoryRepository.setLikeCount(postId, getCountOfLikes(postId) - 1);
-        }
-    }
+    void cancelLike(Long postId, Long userId);
 
     /**
      * '좋아요'를 했었는지 확인
@@ -57,19 +25,7 @@ public class PostLikeService {
      * @param userId 사용자 ID
      * @return 좋아요를 했었는지 반환
      */
-    @Transactional(readOnly = true)
-    public boolean isPostLiked(Long postId, Long userId) {
-        Boolean liked = memoryRepository.isPostLiked(postId, userId);
-        if (liked == null) {
-            liked = persistenceRepository.findByPostIdAndUserId(postId, userId).isPresent();
-            if (liked) {
-                memoryRepository.addPostLike(postId, userId);
-            } else {
-                memoryRepository.removePostLike(postId, userId);
-            }
-        }
-        return liked;
-    }
+    boolean isPostLiked(Long postId, Long userId);
 
     /**
      * 게시글의 '좋아요' 개수 가져오기.
@@ -78,34 +34,5 @@ public class PostLikeService {
      * @param postId 게시글 ID
      * @return 좋아요 개수
      */
-    @Transactional(readOnly = true)
-    public int getCountOfLikes(Long postId) {
-        int count = memoryRepository.getCachedLikeCount(postId);
-        if (count == -1) {
-            count = persistenceRepository.countByPostId(postId);
-            memoryRepository.setLikeCount(postId, count);
-        }
-        return count;
-    }
-
-    /**
-     * 영속성 DB에 실제로 데이터를 반영한다.
-     *
-     * @return 처리한 entity 개수
-     */
-    @Transactional
-    public long dumpToDB() {
-        List<LikeEntry> allLikes = memoryRepository.getAllPostLikes();
-        for (LikeEntry ent : allLikes) {
-            if (ent.getState() == LikeState.LIKED) {
-                User user = userRepository.getReferenceById(ent.getUserId());
-                Post post = postRepository.getReferenceById(ent.getPostId());
-                persistenceRepository.save(new PostLike(user, post));
-            } else if (ent.getState() == LikeState.CANCELLED) {
-                persistenceRepository.deleteByPostIdAndUserId(ent.getPostId(), ent.getUserId());
-            }
-        }
-
-        return allLikes.size();
-    }
+    int getCountOfLikes(Long postId);
 }

--- a/src/main/java/com/dku/council/domain/like/service/impl/DBPostLikeServiceImpl.java
+++ b/src/main/java/com/dku/council/domain/like/service/impl/DBPostLikeServiceImpl.java
@@ -1,0 +1,47 @@
+package com.dku.council.domain.like.service.impl;
+
+import com.dku.council.domain.like.model.entity.PostLike;
+import com.dku.council.domain.like.repository.PostLikePersistenceRepository;
+import com.dku.council.domain.like.service.PostLikeService;
+import com.dku.council.domain.post.model.entity.Post;
+import com.dku.council.domain.post.repository.PostRepository;
+import com.dku.council.domain.user.model.entity.User;
+import com.dku.council.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DBPostLikeServiceImpl implements PostLikeService {
+    private final PostLikePersistenceRepository persistenceRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+
+    @Transactional
+    public void like(Long postId, Long userId) {
+        if (!isPostLiked(postId, userId)) {
+            User user = userRepository.getReferenceById(userId);
+            Post post = postRepository.getReferenceById(postId);
+            persistenceRepository.save(new PostLike(user, post));
+        }
+    }
+
+    @Transactional
+    public void cancelLike(Long postId, Long userId) {
+        if (isPostLiked(postId, userId)) {
+            persistenceRepository.deleteByPostIdAndUserId(postId, userId);
+        }
+    }
+
+    @Override
+    public boolean isPostLiked(Long postId, Long userId) {
+        return persistenceRepository.findByPostIdAndUserId(postId, userId).isPresent();
+    }
+
+    @Transactional(readOnly = true)
+    public int getCountOfLikes(Long postId) {
+        return persistenceRepository.countByPostId(postId);
+    }
+}

--- a/src/main/java/com/dku/council/domain/like/service/impl/RedisPostLikeServiceImpl.java
+++ b/src/main/java/com/dku/council/domain/like/service/impl/RedisPostLikeServiceImpl.java
@@ -1,0 +1,86 @@
+package com.dku.council.domain.like.service.impl;
+
+import com.dku.council.domain.like.model.LikeEntry;
+import com.dku.council.domain.like.model.LikeState;
+import com.dku.council.domain.like.model.entity.PostLike;
+import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
+import com.dku.council.domain.like.repository.PostLikePersistenceRepository;
+import com.dku.council.domain.like.service.PostLikeService;
+import com.dku.council.domain.post.model.entity.Post;
+import com.dku.council.domain.post.repository.PostRepository;
+import com.dku.council.domain.user.model.entity.User;
+import com.dku.council.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RedisPostLikeServiceImpl implements PostLikeService {
+    private final PostLikeMemoryRepository memoryRepository;
+    private final PostLikePersistenceRepository persistenceRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+
+    public void like(Long postId, Long userId) {
+        if (!isPostLiked(postId, userId)) {
+            memoryRepository.addPostLike(postId, userId);
+            memoryRepository.setLikeCount(postId, getCountOfLikes(postId) + 1);
+        }
+    }
+
+    public void cancelLike(Long postId, Long userId) {
+        if (isPostLiked(postId, userId)) {
+            memoryRepository.removePostLike(postId, userId);
+            memoryRepository.setLikeCount(postId, getCountOfLikes(postId) - 1);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isPostLiked(Long postId, Long userId) {
+        Boolean liked = memoryRepository.isPostLiked(postId, userId);
+        if (liked == null) {
+            liked = persistenceRepository.findByPostIdAndUserId(postId, userId).isPresent();
+            if (liked) {
+                memoryRepository.addPostLike(postId, userId);
+            } else {
+                memoryRepository.removePostLike(postId, userId);
+            }
+        }
+        return liked;
+    }
+
+    @Transactional(readOnly = true)
+    public int getCountOfLikes(Long postId) {
+        int count = memoryRepository.getCachedLikeCount(postId);
+        if (count == -1) {
+            count = persistenceRepository.countByPostId(postId);
+            memoryRepository.setLikeCount(postId, count);
+        }
+        return count;
+    }
+
+    /**
+     * 영속성 DB에 실제로 데이터를 반영한다.
+     *
+     * @return 처리한 entity 개수
+     */
+    @Transactional
+    public long dumpToDB() {
+        List<LikeEntry> allLikes = memoryRepository.getAllPostLikes();
+        for (LikeEntry ent : allLikes) {
+            if (ent.getState() == LikeState.LIKED) {
+                User user = userRepository.getReferenceById(ent.getUserId());
+                Post post = postRepository.getReferenceById(ent.getPostId());
+                persistenceRepository.save(new PostLike(user, post));
+            } else if (ent.getState() == LikeState.CANCELLED) {
+                persistenceRepository.deleteByPostIdAndUserId(ent.getPostId(), ent.getUserId());
+            }
+        }
+
+        return allLikes.size();
+    }
+}

--- a/src/main/java/com/dku/council/domain/like/service/impl/RedisPostLikeServiceImpl.java
+++ b/src/main/java/com/dku/council/domain/like/service/impl/RedisPostLikeServiceImpl.java
@@ -70,7 +70,7 @@ public class RedisPostLikeServiceImpl implements PostLikeService {
      */
     @Transactional
     public long dumpToDB() {
-        List<LikeEntry> allLikes = memoryRepository.getAllPostLikes();
+        List<LikeEntry> allLikes = memoryRepository.getAllPostLikesAndClear();
         for (LikeEntry ent : allLikes) {
             if (ent.getState() == LikeState.LIKED) {
                 User user = userRepository.getReferenceById(ent.getUserId());

--- a/src/main/java/com/dku/council/domain/post/controller/GeneralForumController.java
+++ b/src/main/java/com/dku/council/domain/post/controller/GeneralForumController.java
@@ -4,6 +4,7 @@ import com.dku.council.domain.comment.model.dto.CommentDto;
 import com.dku.council.domain.comment.model.dto.RequestCreateCommentDto;
 import com.dku.council.domain.comment.service.CommentService;
 import com.dku.council.domain.like.service.PostLikeService;
+import com.dku.council.domain.like.service.impl.DBPostLikeServiceImpl;
 import com.dku.council.domain.post.model.dto.list.SummarizedGenericPostDto;
 import com.dku.council.domain.post.model.dto.request.RequestCreateGeneralForumDto;
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
@@ -38,6 +39,7 @@ public class GeneralForumController {
     private final CommentService commentService;
     private final GenericPostService<GeneralForum> postService;
     private final PostLikeService postLikeService;
+    private final DBPostLikeServiceImpl dbPostLikeServiceImpl;
 
     /**
      * 게시글 목록 및 태그 조회
@@ -190,5 +192,29 @@ public class GeneralForumController {
     @UserOnly
     public void cancelLike(AppAuthentication auth, @PathVariable Long id) {
         postLikeService.cancelLike(id, auth.getUserId());
+    }
+
+    /**
+     * 게시글에 좋아요 표시. (No cache)
+     * 중복으로 좋아요 표시해도 1개만 적용됩니다.
+     *
+     * @param id 게시글 id
+     */
+    @PostMapping("/like/db/{id}")
+    @UserOnly
+    public void likeDB(AppAuthentication auth, @PathVariable Long id) {
+        dbPostLikeServiceImpl.like(id, auth.getUserId());
+    }
+
+    /**
+     * 좋아요 취소 (No cache)
+     * 중복으로 좋아요 취소해도 최초 1건만 적용됩니다.
+     *
+     * @param id 게시글 id
+     */
+    @DeleteMapping("/like/db/{id}")
+    @UserOnly
+    public void cancelLikeDB(AppAuthentication auth, @PathVariable Long id) {
+        dbPostLikeServiceImpl.cancelLike(id, auth.getUserId());
     }
 }

--- a/src/test/java/com/dku/council/domain/like/service/RedisPostLikeServiceImplTest.java
+++ b/src/test/java/com/dku/council/domain/like/service/RedisPostLikeServiceImplTest.java
@@ -5,6 +5,7 @@ import com.dku.council.domain.like.model.LikeState;
 import com.dku.council.domain.like.model.entity.PostLike;
 import com.dku.council.domain.like.repository.PostLikeMemoryRepository;
 import com.dku.council.domain.like.repository.PostLikePersistenceRepository;
+import com.dku.council.domain.like.service.impl.RedisPostLikeServiceImpl;
 import com.dku.council.domain.post.repository.PostRepository;
 import com.dku.council.domain.user.repository.UserRepository;
 import com.dku.council.mock.NewsMock;
@@ -28,7 +29,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class PostLikeServiceTest {
+class RedisPostLikeServiceImplTest {
 
     @Mock
     private PostLikeMemoryRepository memoryRepository;
@@ -43,7 +44,7 @@ class PostLikeServiceTest {
     private PostRepository postRepository;
 
     @InjectMocks
-    private PostLikeService service;
+    private RedisPostLikeServiceImpl service;
 
     @Test
     @DisplayName("좋아요 - 캐시에 count가 없는 경우")

--- a/src/test/java/com/dku/council/domain/post/service/GenericPostServiceTest.java
+++ b/src/test/java/com/dku/council/domain/post/service/GenericPostServiceTest.java
@@ -1,6 +1,6 @@
 package com.dku.council.domain.post.service;
 
-import com.dku.council.domain.like.service.PostLikeService;
+import com.dku.council.domain.like.service.impl.RedisPostLikeServiceImpl;
 import com.dku.council.domain.post.exception.PostNotFoundException;
 import com.dku.council.domain.post.model.dto.list.SummarizedGenericPostDto;
 import com.dku.council.domain.post.model.dto.list.SummarizedPetitionDto;
@@ -63,7 +63,7 @@ class GenericPostServiceTest {
     private FileUploadService fileUploadService;
 
     @Mock
-    private PostLikeService postLikeService;
+    private RedisPostLikeServiceImpl postLikeService;
 
     private GenericPostService<News> newsService;
     private GenericPostService<Petition> petitionService;


### PR DESCRIPTION
Resolves #185 

`DBPostLikeService`는 DB vs Redis 성능 테스트를 위해 **임시로 만든 클래스**입니다. 향후 삭제될 예정입니다.
`PostLikeService` -> `RedisPostLikeService`로 바꾸고 `PostLikeService`를 인터페이스화 한 이유도 `DBPostLikeService`때문입니다.