### PR TITLE
유저 비밀번호 찾기 및 재설정 수정

### DIFF
--- a/src/main/java/com/dku/council/domain/user/controller/UserController.java
+++ b/src/main/java/com/dku/council/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.user.controller;
 
 import com.dku.council.domain.user.model.dto.request.*;
 import com.dku.council.domain.user.model.dto.response.*;
+import com.dku.council.domain.user.service.SMSVerificationService;
 import com.dku.council.domain.user.service.SignupService;
 import com.dku.council.domain.user.service.UserFindService;
 import com.dku.council.domain.user.service.UserService;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 import java.util.List;
 
 @Tag(name = "사용자", description = "사용자 인증 및 정보 관련 api")
@@ -24,6 +26,7 @@ public class UserController {
     private final UserService userService;
     private final UserFindService userFindService;
     private final SignupService signupService;
+    private final SMSVerificationService smsVerificationService;
 
 
     /**
@@ -57,8 +60,8 @@ public class UserController {
      * @return 비밀번호 재설정 토큰
      */
     @PostMapping("/find/pwd")
-    public ResponsePasswordChangeTokenDto sendPwdCodeBySMS(@Valid @RequestBody RequestSendPasswordFindCodeDto dto) {
-        return userFindService.sendPwdCodeBySMS(dto.getStudentId(), dto.getPhoneNumber());
+    public ResponsePasswordChangeTokenDto sendPwdCodeBySMS(@Valid @RequestBody RequestWithPhoneNumberDto dto) {
+        return userFindService.sendPwdCodeBySMS(dto.getPhoneNumber());
     }
 
     /**
@@ -100,10 +103,10 @@ public class UserController {
      * @param dto 요청 body
      */
     @PatchMapping("/change/password")
+    @UserOnly
     public void changeExistPassword(AppAuthentication auth, @Valid @RequestBody RequestExistPasswordChangeDto dto){
         userService.changePassword(auth.getUserId(), dto);
     }
-
 
     /**
      * 회원가입

--- a/src/main/java/com/dku/council/domain/user/service/UserFindService.java
+++ b/src/main/java/com/dku/council/domain/user/service/UserFindService.java
@@ -49,15 +49,12 @@ public class UserFindService {
     }
 
     @Transactional(readOnly = true)
-    public ResponsePasswordChangeTokenDto sendPwdCodeBySMS(String studentId, String phone) {
+    public ResponsePasswordChangeTokenDto sendPwdCodeBySMS(String phone) {
         Instant now = Instant.now(clock);
         String code = CodeGenerator.generateDigitCode(digitCount);
-        User user = userRepository.findByStudentId(studentId).orElseThrow(UserNotFoundException::new);
+        userRepository.findByPhone(phone).orElseThrow(UserNotFoundException::new);
 
         phone = eliminateDash(phone);
-        if (!user.getPhone().equals(phone)) {
-            throw new UserNotFoundException();
-        }
 
         String token = CodeGenerator.generateUUIDCode();
         userFindRepository.setPwdAuthCode(token, code, phone, now);

--- a/src/main/java/com/dku/council/domain/user/service/UserService.java
+++ b/src/main/java/com/dku/council/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.dku.council.domain.user.exception.WrongPasswordException;
 import com.dku.council.domain.user.model.dto.request.RequestExistPasswordChangeDto;
 import com.dku.council.domain.user.model.dto.request.RequestLoginDto;
 import com.dku.council.domain.user.model.dto.request.RequestNickNameChangeDto;
+import com.dku.council.domain.user.model.dto.request.RequestVerifySMSCodeDto;
 import com.dku.council.domain.user.model.dto.response.ResponseLoginDto;
 import com.dku.council.domain.user.model.dto.response.ResponseMajorDto;
 import com.dku.council.domain.user.model.dto.response.ResponseRefreshTokenDto;
@@ -87,4 +88,5 @@ public class UserService {
             throw new WrongPasswordException();
         }
     }
+
 }

--- a/src/test/java/com/dku/council/domain/user/service/UserFindServiceTest.java
+++ b/src/test/java/com/dku/council/domain/user/service/UserFindServiceTest.java
@@ -82,11 +82,11 @@ class UserFindServiceTest {
     void sendPwdCodeBySMS() {
         // given
         User user = UserMock.createDummyMajor();
-        when(userRepository.findByStudentId(user.getStudentId())).thenReturn(Optional.of(user));
+        when(userRepository.findByPhone(user.getPhone())).thenReturn(Optional.of(user));
         when(messageSource.getMessage(eq("sms.find.pwd-auth-message"), any(), any())).thenReturn("Message");
 
         // when
-        service.sendPwdCodeBySMS(user.getStudentId(), user.getPhone());
+        service.sendPwdCodeBySMS(user.getPhone());
 
         // then
         verify(smsService).sendSMS(user.getPhone(), "Message");
@@ -97,11 +97,11 @@ class UserFindServiceTest {
     void failedSendPwdCodeBySMSByNotFoundUser() {
         // given
         User user = UserMock.createDummyMajor();
-        when(userRepository.findByStudentId(user.getStudentId())).thenReturn(Optional.empty());
+        when(userRepository.findByPhone(user.getPhone())).thenReturn(Optional.empty());
 
         // when & then
         Assertions.assertThrows(UserNotFoundException.class, () ->
-                service.sendPwdCodeBySMS(user.getStudentId(), user.getPhone()));
+                service.sendPwdCodeBySMS(user.getPhone()));
     }
 
     @Test


### PR DESCRIPTION
#183 
해당 요청에서 학번을 제외한 핸드폰 번호만으로 비밀번호 찾기 및 재설정이 가능하도록 수정하였습니다.

- 요청 RequestDto -> 핸드폰 번호만 받도록 수정
- TestCode 수정