### PR TITLE
좋아요 버그 수정

### DIFF
--- a/src/main/java/com/dku/council/domain/like/model/entity/LikeElement.java
+++ b/src/main/java/com/dku/council/domain/like/model/entity/LikeElement.java
@@ -17,7 +17,11 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 @Table(indexes = {
         @Index(name = "idx_like_element_id", columnList = "elementId")
-})
+},
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_like_element", columnNames = {"user_id", "elementId", "target"})
+        }
+)
 public class LikeElement extends BaseEntity {
 
     @Id

--- a/src/main/java/com/dku/council/domain/like/repository/LikeMemoryRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/LikeMemoryRepository.java
@@ -40,6 +40,16 @@ public interface LikeMemoryRepository {
     Boolean isLiked(Long elementId, Long userId, LikeTarget target);
 
     /**
+     * 좋아요 여부를 메모리에 캐싱한다.
+     *
+     * @param elementId 요소 ID
+     * @param userId    사용자 ID
+     * @param target    요소 타입
+     * @param isLiked   좋아요 여부
+     */
+    void setIsLiked(Long elementId, Long userId, LikeTarget target, boolean isLiked);
+
+    /**
      * 메모리에 캐싱된 좋아요 개수 확인.
      *
      * @param elementId 요소 ID

--- a/src/main/java/com/dku/council/domain/like/repository/impl/LikeRedisRepository.java
+++ b/src/main/java/com/dku/council/domain/like/repository/impl/LikeRedisRepository.java
@@ -30,6 +30,7 @@ public class LikeRedisRepository implements LikeMemoryRepository {
 
         key = combine(RedisKeys.LIKE_USERS_KEY, target);
         redisTemplate.opsForSet().add(key, userId.toString());
+        setIsLiked(elementId, userId, target, true);
     }
 
     @Override
@@ -39,11 +40,22 @@ public class LikeRedisRepository implements LikeMemoryRepository {
 
         key = combine(RedisKeys.LIKE_USERS_KEY, target);
         redisTemplate.opsForSet().add(key, userId.toString());
+        setIsLiked(elementId, userId, target, false);
+    }
+
+    @Override
+    public void setIsLiked(Long elementId, Long userId, LikeTarget target, boolean isLiked) {
+        String key = combine(RedisKeys.LIKE_POSTS_KEY, target, userId);
+        String value = LikeState.CANCELLED.toString();
+        if (isLiked) {
+            value = LikeState.LIKED.toString();
+        }
+        redisTemplate.opsForHash().put(key, elementId.toString(), value);
     }
 
     @Override
     public Boolean isLiked(Long elementId, Long userId, LikeTarget target) {
-        String key = combine(RedisKeys.LIKE_KEY, target, userId);
+        String key = combine(RedisKeys.LIKE_POSTS_KEY, target, userId);
         Object value = redisTemplate.opsForHash().get(key, elementId.toString());
         if (value == null) {
             return null;

--- a/src/main/java/com/dku/council/domain/like/service/impl/CachedLikeServiceImpl.java
+++ b/src/main/java/com/dku/council/domain/like/service/impl/CachedLikeServiceImpl.java
@@ -49,11 +49,7 @@ public class CachedLikeServiceImpl implements LikeService {
         Boolean liked = memoryRepository.isLiked(elementId, userId, target);
         if (liked == null) {
             liked = persistenceRepository.findByElementIdAndUserId(elementId, userId, target).isPresent();
-            if (liked) {
-                memoryRepository.like(elementId, userId, target);
-            } else {
-                memoryRepository.cancelLike(elementId, userId, target);
-            }
+            memoryRepository.setIsLiked(elementId, userId, target, liked);
         }
         return liked;
     }

--- a/src/main/java/com/dku/council/global/config/redis/RedisKeys.java
+++ b/src/main/java/com/dku/council/global/config/redis/RedisKeys.java
@@ -6,6 +6,7 @@ public class RedisKeys {
     public static final String POST_VIEW_COUNT_SET_KEY = "postViewSet";
 
     public static final String LIKE_KEY = "like";
+    public static final String LIKE_POSTS_KEY = "likePosts";
     public static final String LIKE_USERS_KEY = "likeUsers";
     public static final String LIKE_COUNT_KEY = "likeCount";
 

--- a/src/test/java/com/dku/council/domain/like/repository/impl/LikeRedisRepositoryTest.java
+++ b/src/test/java/com/dku/council/domain/like/repository/impl/LikeRedisRepositoryTest.java
@@ -41,6 +41,7 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
 
         // then
         assertThat(key.getLike(redisTemplate)).isEqualTo(LikeState.LIKED.name());
+        assertThat(key.isLiked(redisTemplate)).isEqualTo(true);
     }
 
     @Test
@@ -55,6 +56,7 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
 
         // then
         assertThat(key.getLike(redisTemplate)).isEqualTo(LikeState.LIKED.name());
+        assertThat(key.isLiked(redisTemplate)).isEqualTo(true);
     }
 
     @Test
@@ -69,6 +71,7 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
 
         // then
         assertThat(key.getLike(redisTemplate)).isEqualTo(LikeState.CANCELLED.name());
+        assertThat(key.isLiked(redisTemplate)).isEqualTo(false);
     }
 
     @Test
@@ -82,6 +85,7 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
 
         // then
         assertThat(key.getLike(redisTemplate)).isEqualTo(LikeState.CANCELLED.name());
+        assertThat(key.isLiked(redisTemplate)).isEqualTo(false);
     }
 
     @Test
@@ -89,7 +93,7 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
     void isPostLiked() {
         // given
         PostLikeKey key = new PostLikeKey();
-        repository.like(key.elementId, key.userId, POST);
+        key.setLiked(redisTemplate, true);
 
         // when
         Boolean value = repository.isLiked(key.elementId, key.userId, POST);
@@ -103,7 +107,7 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
     void isPostLikedCancelled() {
         // given
         PostLikeKey key = new PostLikeKey();
-        repository.cancelLike(key.elementId, key.userId, POST);
+        key.setLiked(redisTemplate, false);
 
         // when
         Boolean value = repository.isLiked(key.elementId, key.userId, POST);
@@ -218,9 +222,19 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
             redisTemplate.opsForValue().set(key, data);
         }
 
-        public boolean isMember(StringRedisTemplate redisTemplate) {
-            String key = combine(RedisKeys.LIKE_USERS_KEY, POST);
-            return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, elementId.toString()));
+        public boolean isLiked(StringRedisTemplate redisTemplate) {
+            String key = combine(RedisKeys.LIKE_POSTS_KEY, POST, userId);
+            Object value = redisTemplate.opsForHash().get(key, elementId.toString());
+            return LikeState.LIKED.toString().equals(value);
+        }
+
+        public void setLiked(StringRedisTemplate redisTemplate, boolean isLiked) {
+            String key = combine(RedisKeys.LIKE_USERS_KEY, POST, userId);
+            String value = LikeState.CANCELLED.toString();
+            if (isLiked) {
+                value = LikeState.LIKED.toString();
+            }
+            redisTemplate.opsForHash().put(key, elementId.toString(), value);
         }
     }
 }

--- a/src/test/java/com/dku/council/domain/like/repository/impl/LikeRedisRepositoryTest.java
+++ b/src/test/java/com/dku/council/domain/like/repository/impl/LikeRedisRepositoryTest.java
@@ -225,14 +225,14 @@ class LikeRedisRepositoryTest extends AbstractContainerRedisTest {
         public boolean isLiked(StringRedisTemplate redisTemplate) {
             String key = combine(RedisKeys.LIKE_POSTS_KEY, POST, userId);
             Object value = redisTemplate.opsForHash().get(key, elementId.toString());
-            return LikeState.LIKED.toString().equals(value);
+            return LikeState.LIKED.name().equals(value);
         }
 
         public void setLiked(StringRedisTemplate redisTemplate, boolean isLiked) {
-            String key = combine(RedisKeys.LIKE_USERS_KEY, POST, userId);
-            String value = LikeState.CANCELLED.toString();
+            String key = combine(RedisKeys.LIKE_POSTS_KEY, POST, userId);
+            String value = LikeState.CANCELLED.name();
             if (isLiked) {
-                value = LikeState.LIKED.toString();
+                value = LikeState.LIKED.name();
             }
             redisTemplate.opsForHash().put(key, elementId.toString(), value);
         }

--- a/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceImplTest.java
+++ b/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceImplTest.java
@@ -160,6 +160,7 @@ class CachedLikeServiceImplTest {
 
         // then
         assertThat(liked).isEqualTo(false);
+        verify(memoryRepository).setIsLiked(10L, 10L, POST, false);
     }
 
     @Test
@@ -175,6 +176,7 @@ class CachedLikeServiceImplTest {
 
         // then
         assertThat(liked).isEqualTo(true);
+        verify(memoryRepository).setIsLiked(10L, 10L, POST, true);
     }
 
     @Test

--- a/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceImplTest.java
+++ b/src/test/java/com/dku/council/domain/like/service/CachedLikeServiceImplTest.java
@@ -176,7 +176,7 @@ class CachedLikeServiceImplTest {
 
         // then
         assertThat(liked).isEqualTo(true);
-        verify(memoryRepository).setIsLiked(10L, 10L, POST, true);
+        verify(memoryRepository).setIsLiked(5L, 10L, POST, true);
     }
 
     @Test


### PR DESCRIPTION
좋아요 설계를 약간 수정했습니다.

### 기존 방식
 - 좋아요 여부 확인시 캐시에 없으면 DB에서 가져와서 좋아요 누른 처리.
   - 좋아요 누름, 좋아요 여부 이 2개가 서로 같은 redis key를 사용했기 때문에 구분 불가.
 - 이렇게 하면 나중에 캐시 -> DB로 dump할 때 좋아요 누른 처리로 간주 (즉 중복으로 데이터가 포함됨)

### 새로운 방식
 - 좋아요 여부와 좋아요 누르기를 분리해서 저장.
 - DB에 dump할 때는 좋아요 누른 경우만 골라서 dump.